### PR TITLE
Update root/includes/acp/acp_dkp_bossprogress.php

### DIFF
--- a/root/includes/acp/acp_dkp_bossprogress.php
+++ b/root/includes/acp/acp_dkp_bossprogress.php
@@ -483,7 +483,6 @@ class acp_dkp_bossprogress extends bbDKP_Admin
 					
 					$sql = $db->sql_build_query('SELECT', $sql_array);
 					$result = $db->sql_query($sql);
-	                $row = $db->sql_fetchrow($result); 
 	                while ( $row = $db->sql_fetchrow($result) )
 	                {
 	                	$zoneid = $row['id'];


### PR DESCRIPTION
Removed a line which was causing the first zone in the boss configuration list in the ACP to not show.
The temporary workaround was to create a dummy zone on the zone configuration page and move it to the bottom of the zone list.
